### PR TITLE
fix: correct contact validation logic in main.js

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -344,10 +344,10 @@ $(document).ready(function () {
 
         if (Name.length > 0 && MobileNo.length > 0) {
 
-            if (Email.length < 0) {
+            if (Email.length === 0) {
                 Email = "";
             }
-            else if (City < 0) {
+            else if (City.length === 0) {
                 City = "";
             }
 


### PR DESCRIPTION
Fix two bugs in the AddContactBtn handler:
- `Email.length < 0` can never be true (array lengths are always >= 0); changed to `Email.length === 0`
- `City < 0` compares a string to a number; changed to `City.length === 0` This ensures empty email/city fields default to empty string correctly.