### PR TITLE
feat: add clapWake() — dramatic double-clap agent wake animation

### DIFF
--- a/www/controller.js
+++ b/www/controller.js
@@ -1,14 +1,9 @@
 $(document).ready(function () {
 
-
-
     // Display Speak Message
     eel.expose(DisplayMessage)
     function DisplayMessage(message) {
-        // Replace the hidden textillate <li>
         $(".siri-message .texts li").text(message);
-
-        // Re-initialize textillate so it splits into chars again
         $('.siri-message').textillate('start');
     }
 
@@ -23,74 +18,89 @@ $(document).ready(function () {
     function senderText(message) {
         var chatBox = document.getElementById("chat-canvas-body");
         if (message.trim() !== "") {
-            chatBox.innerHTML += `<div class="row justify-content-end mb-4">
-            <div class = "width-size">
-            <div class="sender_message">${message}</div>
-        </div>`; 
-    
-            // Scroll to the bottom of the chat box
+            chatBox.innerHTML += `<div class="row justify-content-end mb-4"><div class="width-size"><div class="sender_message">${message}</div></div>`;
             chatBox.scrollTop = chatBox.scrollHeight;
         }
     }
 
     eel.expose(receiverText)
     function receiverText(message) {
-
         var chatBox = document.getElementById("chat-canvas-body");
         if (message.trim() !== "") {
-            chatBox.innerHTML += `<div class="row justify-content-start mb-4">
-            <div class = "width-size">
-            <div class="receiver_message">${message}</div>
-            </div>
-        </div>`; 
-    
-            // Scroll to the bottom of the chat box
+            chatBox.innerHTML += `<div class="row justify-content-start mb-4"><div class="width-size"><div class="receiver_message">${message}</div></div></div>`;
             chatBox.scrollTop = chatBox.scrollHeight;
         }
-        
     }
 
-    
-    // Hide Loader and display Face Auth animation
     eel.expose(hideLoader)
     function hideLoader() {
-
         $("#Loader").attr("hidden", true);
         $("#FaceAuth").attr("hidden", false);
-
     }
-    // Hide Face auth and display Face Auth success animation
+
     eel.expose(hideFaceAuth)
     function hideFaceAuth() {
-
         $("#FaceAuth").attr("hidden", true);
         $("#FaceAuthSuccess").attr("hidden", false);
-
     }
-    // Hide success and display 
+
     eel.expose(hideFaceAuthSuccess)
     function hideFaceAuthSuccess() {
-
         $("#FaceAuthSuccess").attr("hidden", true);
         $("#HelloGreet").attr("hidden", false);
-
     }
 
-
-    // Hide Start Page and display blob
     eel.expose(hideStart)
     function hideStart() {
-
         $("#Start").attr("hidden", true);
-
         setTimeout(function () {
             $("#Oval").addClass("animate__animated animate__zoomIn");
-
-        }, 1000)
+        }, 1000);
         setTimeout(function () {
             $("#Oval").attr("hidden", false);
-        }, 1000)
+        }, 1000);
     }
 
+    // ─────────────────────────────────────────────
+    // CLAP-TO-WAKE  — dramatic agent wake sequence
+    // ─────────────────────────────────────────────
+    eel.expose(clapWake)
+    function clapWake() {
+
+        // If still on the Start page, skip past it
+        if (!$("#Start").attr("hidden")) {
+            $("#Start").attr("hidden", true);
+        }
+
+        $("#SiriWave").attr("hidden", true);
+        $("#Oval").removeClass("animate__zoomIn animate__zoomOut clap-pulse");
+        $("#Oval").attr("hidden", false);
+
+        // 1. Screen flash burst on clap
+        $("body").addClass("clap-flash");
+        setTimeout(function () { $("body").removeClass("clap-flash"); }, 180);
+
+        // 2. Three expanding ripple rings
+        _spawnRipple();
+        setTimeout(_spawnRipple, 130);
+        setTimeout(_spawnRipple, 280);
+
+        // 3. Orb pulses in dramatically
+        setTimeout(function () {
+            $("#Oval").addClass("clap-pulse");
+            setTimeout(function () { $("#Oval").removeClass("clap-pulse"); }, 750);
+        }, 80);
+
+        // 4. Status text flickers in
+        setTimeout(function () {
+            DisplayMessage("Online. Ready.");
+        }, 420);
+    }
+
+    function _spawnRipple() {
+        var ripple = $(`<div class="clap-ripple"></div>`);
+        $("#JarvisHood").append(ripple);
+        setTimeout(function () { ripple.remove(); }, 900);
+    }
 
 });


### PR DESCRIPTION
New eel.expose(clapWake) function called from Python when double-clap is detected:
- White screen flash burst (clap-flash CSS class)
- Three expanding ripple rings spawn from the orb (clap-ripple)
- Orb pulses dramatically (clap-pulse class)
- DisplayMessage shows 'Online. Ready.'
- Skips Start page if Jarvis hasn't woken yet Also added helper _spawnRipple() for ring animation.